### PR TITLE
fixed regexp for working with "seo.gruz0.ru"

### DIFF
--- a/src/Phois/Whois/Whois.php
+++ b/src/Phois/Whois/Whois.php
@@ -20,7 +20,7 @@ class Whois
         $this->domain = $domain;
         // check $domain syntax and split full domain name on subdomain and TLDs
         if (
-            preg_match('/^([\p{L}\d\-]+)\.((?:[\p{L}\-]+\.?)+)$/ui', $this->domain, $matches)
+            preg_match('/^([\p{L}\d\-]+)\.((?:[\p{L}\d\-]+\.?)+)$/ui', $this->domain, $matches)
             || preg_match('/^(xn\-\-[\p{L}\d\-]+)\.(xn\-\-(?:[a-z\d-]+\.?1?)+)$/ui', $this->domain, $matches)
         ) {
             $this->subDomain = $matches[1];


### PR DESCRIPTION
# Why?
Pull in a bugfix we need to support subdomains of domains with numbers (eg something.12z.ai)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask someone. This is simply a reminder of what we are going to look for before merging your code._
- [ ] My PR adequately explains these changes so that others can understand them
- [ ] I have performed a self-review of my own code
- [ ] Any dependent changes have been merged and published in other modules (or PR's linked in this PR)
- [ ] My code follows the style used in this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and linked it in the PR
- [ ] My changes generate no new warnings or excessive logging
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
